### PR TITLE
feat(backend): Finished edit event api method

### DIFF
--- a/backend/src/routes/event.js
+++ b/backend/src/routes/event.js
@@ -72,13 +72,20 @@ router.put("/", async (req, res) => {
   // Update event
   const query = `
         UPDATE event
-        SET title = $1, description = $2, start_date = $3, end_date = $4
-        WHERE id = $5
+        SET title = $1, description = $2, is_recurring = $3, is_private = $4, days_of_week = $5, event_frequency = $6, event_tags = $7, date = $8, end_period = $9, start_date = $10, end_date = $11
+        WHERE id = ${req.query.id}
       `;
 
   const values = [
     event.title,
     event.description,
+    event.is_recurring,
+    event.is_private,
+    event.days_of_week,
+    event.event_frequency,
+    event.event_tags,
+    event.date,
+    event.end_period,
     event.start_date,
     event.end_date,
     event.id,
@@ -87,5 +94,5 @@ router.put("/", async (req, res) => {
 
   res.json({ message: "Successfully updated" });
 });
-  
+
 module.exports = router;

--- a/web/src/helpers/api.js
+++ b/web/src/helpers/api.js
@@ -30,7 +30,20 @@ export default class Api {
     return (await (await this.init(token)).get("/api/example")).data;
   };
 
-  createEvent = async (token, title, description, is_recurring, is_private, days_of_week, event_frequency, event_tags, date, end_period, start_date, end_date) => {
+  createEvent = async (
+    token,
+    title,
+    description,
+    is_recurring,
+    is_private,
+    days_of_week,
+    event_frequency,
+    event_tags,
+    date,
+    end_period,
+    start_date,
+    end_date
+  ) => {
     return (await this.init(token)).post("/api/event", {
       title,
       description,
@@ -39,7 +52,7 @@ export default class Api {
       days_of_week,
       event_frequency,
       event_tags,
-      date, 
+      date,
       end_period,
       start_date,
       end_date,
@@ -48,5 +61,35 @@ export default class Api {
 
   getEvents = async (token) => {
     return (await (await this.init(token)).get("/api/event")).data;
-  }
+  };
+
+  editEvent = async (
+    token,
+    id,
+    title,
+    description,
+    is_recurring,
+    is_private,
+    days_of_week,
+    event_frequency,
+    event_tags,
+    date,
+    end_period,
+    start_date,
+    end_date
+  ) => {
+    return (await this.init(token)).put(`/api/event?id=${id}`, {
+      title,
+      description,
+      is_recurring,
+      is_private,
+      days_of_week,
+      event_frequency,
+      event_tags,
+      date,
+      end_period,
+      start_date,
+      end_date,
+    });
+  };
 }


### PR DESCRIPTION
- Fixes bug in the original edit_event API method (id of the event edited wasn't passed through the call)
- Can now edit recurring events as well 
- Tested on the [edit-recurring-event-backend](https://github.com/ECSE-428-Group-5-W-2023/OnCampus/tree/edit-recurring-event-backend) branch through the basic Frontend implemented there and through checking the changes on the database directly as well 
- Closes #39 
