### PR TITLE
feat(web): allow ICS file import

### DIFF
--- a/backend/src/routes/event.js
+++ b/backend/src/routes/event.js
@@ -91,15 +91,14 @@ router.put("/", async (req, res) => {
 });
 
 router.delete("/", async (req, res) => {
-
   // Delete event
   const query = `
         DELETE FROM event WHERE id = ${req.query.id} 
       `;
 
-      await pool.query(query);
+  await pool.query(query);
 
   res.json({ message: "Successfully deleted" });
 });
-  
+
 module.exports = router;

--- a/db/database.sql
+++ b/db/database.sql
@@ -14,11 +14,11 @@ CREATE TABLE "event" (
     "all_day" BOOLEAN,
     "start_date" VARCHAR(255),
     "end_date" VARCHAR(255),
-    CONSTRAINT "todo_fk1" FOREIGN KEY ("event_list_id") REFERENCES "event_list"("id")
+    CONSTRAINT "event_fk1" FOREIGN KEY ("event_list_id") REFERENCES "event_list"("id")
 );
 CREATE TABLE "profile" (
     "id" SERIAL PRIMARY KEY,
-    "profile_id" VARCHAR(255) NOT NULL,
+    "profile_id" VARCHAR(255) NOT NULL UNIQUE,
     "email" VARCHAR(255),
     "name" VARCHAR(255),
     "username" VARCHAR(255),
@@ -28,6 +28,6 @@ CREATE TABLE "profile" (
 CREATE TABLE "friend_group" (
     "id" SERIAL PRIMARY KEY,
     "group_name" VARCHAR(255),
-    "profile_id" integer NOT NULL,
-    CONSTRAINT "todo_fk1" FOREIGN KEY ("profile_id") REFERENCES "profile"("profile_id")
+    "profile_id" VARCHAR(255)  NOT NULL,
+    CONSTRAINT "friend_group_fk1" FOREIGN KEY ("profile_id") REFERENCES "profile"("profile_id")
 );

--- a/web/src/components/Schedule/Schedule.jsx
+++ b/web/src/components/Schedule/Schedule.jsx
@@ -20,6 +20,8 @@ import {
   AllDayPanel,
 } from "@devexpress/dx-react-scheduler-material-ui";
 import Popup from "../Common/Popup";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faUpload } from "@fortawesome/free-solid-svg-icons";
 
 export default function Schedule() {
   const { getAccessTokenSilently } = useAuth0();
@@ -31,8 +33,116 @@ export default function Schedule() {
   const [modalDescription, setModalDescription] = useState(false);
 
   const [mappedEvents, setMappedEvents] = useState([]);
+  const [file, setFile] = useState(null);
 
   const api = new Api();
+
+  const handleFileChange = (event) => {
+    console.log(event.target.files[0]);
+    setFile(event.target.files[0]);
+  };
+
+  const handleFileUpload = async () => {
+    if (file) {
+      // Process the file here
+      var reader = new FileReader();
+      reader.onload = function (e) {
+        // Use reader.result
+        const events = parseICalData(reader.result);
+        for (let i = 0; i < events.length; i++) {
+          const event = events[i];
+          console.log(event);
+          createEvent(
+            event.summary,
+            event.location,
+            undefined,
+            undefined,
+            false,
+            event.start,
+            event.end
+          );
+        }
+        setFile(null);
+      };
+      reader.readAsText(file);
+      console.log(`Processing file: ${file.name}`);
+    } else {
+      console.log("Please select a file to upload");
+    }
+  };
+
+  function parseICalData(data) {
+    const events = [];
+    const lines = data.split(/\r?\n/);
+
+    let event = null;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const matches = line.match(/^([A-Z]+)(;.+)?:(.*)$/);
+      if (!matches) {
+        continue;
+      }
+
+      const prop = matches[1];
+      const value = matches[3];
+
+      switch (prop) {
+        case "BEGIN":
+          if (value === "VEVENT") {
+            event = {};
+          }
+          break;
+        case "END":
+          if (value === "VEVENT") {
+            events.push(event);
+            event = null;
+          }
+          break;
+        case "UID":
+          if (event) {
+            event.uid = value;
+          }
+          break;
+        case "SUMMARY":
+          if (event) {
+            event.summary = value;
+          }
+          break;
+        case "DTSTART":
+          if (event) {
+            const year = value.slice(0, 4);
+            const month = parseInt(value.slice(4, 6)) - 1;
+            const day = value.slice(6, 8);
+            const hour = value.slice(9, 11);
+            const minute = value.slice(11, 13);
+            const second = value.slice(13, 15);
+            event.start = new Date(year, month, day, hour, minute, second);
+          }
+          break;
+        case "DTEND":
+          if (event) {
+            const year = value.slice(0, 4);
+            const month = parseInt(value.slice(4, 6)) - 1;
+            const day = value.slice(6, 8);
+            const hour = value.slice(9, 11);
+            const minute = value.slice(11, 13);
+            const second = value.slice(13, 15);
+            event.end = new Date(year, month, day, hour, minute, second);
+          }
+          break;
+        case "LOCATION":
+          if (event) {
+            event.location = value;
+          }
+          break;
+        default:
+          // Ignore any other properties
+          break;
+      }
+    }
+
+    return events;
+  }
 
   const TextEditor = (props) => {
     // eslint-disable-next-line react/destructuring-assignment
@@ -255,6 +365,34 @@ export default function Schedule() {
           <AllDayPanel />
         </Scheduler>
       </Paper>
+
+      <div className="flex flex-col items-center md:flex-row md:items-center md:space-x-4 mt-2 ">
+        <label
+          for="file-upload"
+          className="flex items-center justify-center w-full md:w-auto mb-3 md:mb-0"
+        >
+          <FontAwesomeIcon
+            icon={faUpload}
+            className="mx-2 hover:cursor-pointer bg-white  p-2 rounded"
+          />
+          <span className="text-white hover:cursor-pointer ">
+            {file?.name ? file.name : "Choose ICS file to upload"}
+          </span>
+        </label>
+        <input
+          id="file-upload"
+          type="file"
+          className="hidden"
+          onChange={handleFileChange}
+        />
+
+        <button
+          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+          onClick={handleFileUpload}
+        >
+          Upload and Process File
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
It would be pretty difficult to fetch the course stuff from McGill directly, as there are no APIs available. The alternative presented here is the ability to parse ICS files that can be generated using McGill enhanced. Will attach an example ICS for testing
![image](https://user-images.githubusercontent.com/72809488/227430631-95940401-0a7d-463d-9c39-582622957bb6.png)

Does not handle the event repetitions just yet, WIP

Closes: https://github.com/ECSE-428-Group-5-W-2023/OnCampus/issues/90
Closes: https://github.com/ECSE-428-Group-5-W-2023/OnCampus/issues/124

Don't forget to remove the .txt and simply have an .ics file when using this
[CourseScheduleWinter2023.ics.txt](https://github.com/ECSE-428-Group-5-W-2023/OnCampus/files/11058617/CourseScheduleWinter2023.ics.txt)
NOTE: check the first two weeks of January to see the schedule
